### PR TITLE
パスワードの再設定ができるように変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :set_host
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protect_from_forgery with: :exception
@@ -15,4 +16,7 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:name, :email, :password, :profile, :icon,  :password, :coverimg, :tag) }
   end
 
+  def set_host
+    ActionMailer::Base.default_url_options = {:host => "https://" + request.host_with_port}
+  end
 end

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,13 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %> 様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>いつもイチオシ！をご利用いただきありがとうございます。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p>パスワードを再設定する場合は下記リンクから設定して下さい</p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= link_to 'パスワード再設定', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>このメールに心当たりがなければ無視して下さい</p>
+
+<p>ISHIOSHI運営チーム</p>
+<a href="https://goo.gl/forms/QzygIRY5UlgtNqYm1">お問い合わせ</a>
+

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -20,10 +20,6 @@
               <%= f.password_field :password, autocomplete: "off", placeholder: "８文字以上の英数字", :class => "form-control" %>
             </div>
             <div class="field col-md-12">
-              <%= f.label :password_confirmation %><br />
-              <%= f.password_field :password_confirmation, autocomplete: "off", placeholder: '同じものを入力', :class => "form-control" %>
-            </div>
-            <div class="field col-md-12">
               <%= f.check_box :accepted , {}, checked_value = "true", unchecked_value = "false" %>
               <%= link_to "利用規約",'/rule' %> に同意する
             </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,14 @@ module Tamtim
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.action_mailer.smtp_settings = {
+      :user_name => ENV['SENDGRID_USER_NAME'],
+      :password => ENV['SENDGRID_PASSWORD'],
+      :domain => 'y',
+      :address => 'smtp.sendgrid.net',
+      :port => 587,
+      :authentication => :plain,
+      :enable_starttls_auto => true
+    }
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'no-reply@ichioshi.tokyo'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
メールサーバーをsendgridにしてドメインをishioshi.tokyoに。
