### PR TITLE
thinをuninstall

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'thin'
   gem 'html2slim'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,6 @@ GEM
       activesupport (>= 3.0.0)
       after_commit_action (~> 1.0)
     crass (1.0.4)
-    daemons (1.2.6)
     debug_inspector (0.0.3)
     devise (4.4.3)
       bcrypt (~> 3.0)
@@ -109,7 +108,6 @@ GEM
       dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
     erubi (1.7.1)
-    eventmachine (1.2.7)
     excon (0.62.0)
     execjs (2.7.0)
     faraday (0.12.2)
@@ -288,10 +286,6 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     temple (0.8.0)
-    thin (1.7.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -356,11 +350,10 @@ DEPENDENCIES
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)
-  thin
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   2.0.1
+   2.1.4


### PR DESCRIPTION
facebookログインをローカルで行うのにhttps通信が必要で手軽に導入できるthinを導入していたが
native extensionでinstall時に問題も起きやすく、あまり更新もされていないのuninstallする。

pumaでssl対応してfacebookログインはできるようにする予定。

一時的にfacebookログインはできなくなるが、bundle installに失敗するよりマシなので一旦消します。