### PR TITLE
環境変数で読み込めない場合dummyコードを読みこむように修正

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,9 +50,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   Amazon::Ecs.options = {
-    associate_tag: ENV['AWS_ASSOCIATE_TAG'],
-    AWS_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-    AWS_secret_key: ENV['AWS_SECRET_KEY']
+    associate_tag: ENV['AWS_ASSOCIATE_TAG'] || 'dummy',
+    AWS_access_key_id: ENV['AWS_ACCESS_KEY_ID'] || 'dummy',
+    AWS_secret_key: ENV['AWS_SECRET_KEY'] || 'dummy',
   }
 
   # Use an evented file watcher to asynchronously detect changes in source code,

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -2,8 +2,8 @@ CarrierWave.configure do |config|
     config.fog_provider = 'fog/aws'
     config.fog_credentials = {
         provider: 'AWS',
-        aws_access_key_id: ENV['ACCESS_KEY_ID'],
-        aws_secret_access_key: ENV['SECRET_ACCESS_KEY'],
+        aws_access_key_id: ENV['ACCESS_KEY_ID'] || 'dummy',
+        aws_secret_access_key: ENV['SECRET_ACCESS_KEY'] || 'dummy',
         region: 'ap-northeast-1'#リージョンをUS以外にしたかたはそのリージョンに変更
     }
 


### PR DESCRIPTION
将来的にはmulti enviroment credentialsを使ってsecrets管理するのが理想だが、
一旦環境変数設定していない場合に`rails s`に失敗しないようにダミーのトークンを設定した